### PR TITLE
Bugfix apikey name regex

### DIFF
--- a/src/Console/Commands/GenerateApiKey.php
+++ b/src/Console/Commands/GenerateApiKey.php
@@ -10,7 +10,7 @@ class GenerateApiKey extends Command
     /**
      * Error messages
      */
-    const MESSAGE_ERROR_INVALID_NAME_FORMAT = 'Invalid name.  Must be a lowercase alphabetic characters and hyphens less than 255 characters long.';
+    const MESSAGE_ERROR_INVALID_NAME_FORMAT = 'Invalid name.  Must be a lowercase alphabetic characters, numbers and hyphens less than 255 characters long.';
     const MESSAGE_ERROR_NAME_ALREADY_USED   = 'Name is unavailable.';
 
     /**

--- a/src/Models/ApiKey.php
+++ b/src/Models/ApiKey.php
@@ -14,7 +14,7 @@ class ApiKey extends Model
     const EVENT_NAME_DEACTIVATED = 'deactivated';
     const EVENT_NAME_DELETED     = 'deleted';
 
-    protected static $nameRegex = '/^[a-z-]{1,255}$/';
+    protected static $nameRegex = '/^[a-z0-9-]{1,255}$/';
 
     protected $table = 'api_keys';
 


### PR DESCRIPTION
This pull request fixes an issue with apikey names

The regex used to validate the name, did not allow numbers

```bash
php artisan apikey:generate app1
Invalid name.  Must be a lowercase alphabetic characters and hyphens less than 255 characters long
```