### PR TITLE
Laravel 6 support (helper function deprecated)

### DIFF
--- a/src/Models/ApiKey.php
+++ b/src/Models/ApiKey.php
@@ -4,6 +4,7 @@ namespace Ejarnutowski\LaravelApiKey\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class ApiKey extends Model
 {
@@ -76,7 +77,7 @@ class ApiKey extends Model
     public static function generate()
     {
         do {
-            $key = str_random(64);
+            $key = Str::random(64);
         } while (self::keyExists($key));
 
         return $key;


### PR DESCRIPTION
## Description

Since Laravel 6, strings & array helper functions are not supported anymore.

## Proposal

Replaced str_random with Str class helper methods